### PR TITLE
filter out already seen changes

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run
         run: |
           poetry install
-          poetry run python main.py -c config/default.yaml -o changelog.md
+          poetry run python main.py -c config/default.yaml -o changelog.md --use-redis
       - uses: danielmcconville/gist-sync-file-action@v2.0.0
         with:
           gistPat: ${{ secrets.GIST_TOKEN }}

--- a/exchange_changelog/redis.py
+++ b/exchange_changelog/redis.py
@@ -1,0 +1,20 @@
+import functools
+import os
+
+import redis
+
+
+@functools.cache
+def get_redis_client() -> redis.Redis:
+    host = os.getenv("REDIS_HOST", "localhost")
+    port = os.getenv("REDIS_PORT", 6379)
+    db = os.getenv("REDIS_DB", 0)
+    return redis.Redis(host=host, port=port, db=db)
+
+
+def exists(key: str) -> int:
+    return get_redis_client().exists(key)
+
+
+def set(key: str, value: str) -> bool:
+    return get_redis_client().set(key, value)

--- a/poetry.lock
+++ b/poetry.lock
@@ -43,6 +43,17 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.3"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
+    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -1773,6 +1784,24 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "5.1.1"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "redis-5.1.1-py3-none-any.whl", hash = "sha256:f8ea06b7482a668c6475ae202ed8d9bcaa409f6e87fb77ed1043d912afd62e24"},
+    {file = "redis-5.1.1.tar.gz", hash = "sha256:f6c997521fedbae53387307c5d0bf784d9acc28d9f1d058abeac566ec4dbed72"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+
+[package.extras]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -2192,4 +2221,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e52fb0e927d6a1c727a71388b4b63c3f01c31be7a863bf5a2739cc05fe03a976"
+content-hash = "003ef9ff81b4c7813c932a6d38ead85482d1aefd1b9fb06fa95c33bd9d6b4034"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ markdownify = "^0.13.1"
 pyyaml = "^6.0.2"
 slack-sdk = "^3.33.1"
 gradio = "^5.1.0"
+redis = "^5.1.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This pull request introduces the use of Redis for filtering out already seen changes in the changelog generation process. The most important changes include adding a new command-line option to enable Redis, updating the workflow to use this option, and modifying the main script to integrate Redis for filtering.

Integration of Redis:

* [`.github/workflows/cron.yml`](diffhunk://#diff-69b9772a7fe51bd7c367926862d89ca7d8949cc9832b3645e610a1ec5bfa1ddfL23-R23): Updated the workflow to include the `--use-redis` flag when running the main script.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R9): Added an import for Redis and a new command-line option `--use-redis` to enable Redis usage. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R9) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L53-R55)
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R66-R77): Modified the `main` function to filter out already seen changes using Redis if the `--use-redis` option is specified.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R22): Added `redis` as a new dependency.