### PR TITLE
Load HTML content using playwright

### DIFF
--- a/exchange_changelog/html.py
+++ b/exchange_changelog/html.py
@@ -70,3 +70,17 @@ def load_html_with_httpx(url: str) -> str:
     text = remove_base64_image(text)
 
     return text
+
+
+def load_url_with_playwright(url: str) -> str:
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(url, wait_until="networkidle")
+        text = page.content()
+        browser.close()
+
+    text = markdownify(text, strip=["a", "img"])
+    return text


### PR DESCRIPTION
This pull request introduces a new function to load HTML content using Playwright in the `exchange_changelog/html.py` file. The most important change is the addition of the `load_url_with_playwright` function.

New functionality:

* [`exchange_changelog/html.py`](diffhunk://#diff-faca333fdbbe9d7df02128a0fcc505af3620a6bbf30b1fa336b0ebdc387b4b83R73-R86): Added the `load_url_with_playwright` function, which uses Playwright to load a URL, waits until the network is idle, retrieves the page content, and processes it with `markdownify`.