### PR TITLE
add dev crcon job

### DIFF
--- a/.github/workflows/cron-dev.yml
+++ b/.github/workflows/cron-dev.yml
@@ -1,0 +1,27 @@
+name: Cron Dev
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 0 */7 * *"
+
+jobs:
+  cron:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run
+        run: |
+          poetry install
+          poetry run python main.py -c config/default.yaml -o changelog.md
+        env:
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SINGLEFILE_PATH: ${{ secrets.SINGLEFILE_PATH }}
+      - uses: danielmcconville/gist-sync-file-action@v2.0.0
+        with:
+          gistPat: ${{ secrets.GIST_TOKEN }}
+          action: update
+          filename: changelog-dev.md
+          gistId: ${{ secrets.GIST_ID }}
+          createIfNotExists: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running a scheduled job in the development environment. The most important changes include setting up the workflow, configuring environment variables, and running the necessary scripts.

New GitHub Actions Workflow:

* [`.github/workflows/cron-dev.yml`](diffhunk://#diff-59fa2950855f7ee343e2411c759506ec31585d1d4d95c2cf3a9d2a3e57fa1f23R1-R28): Added a new workflow named "Cron Dev" that can be triggered manually or scheduled. The workflow sets up environment variables from secrets, installs dependencies using Poetry, runs a Python script, and updates a Gist with the output.