### PR TITLE
Run the workflow weekly on Mondays instead of every 7 days

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,8 +2,9 @@ name: Cron
 
 on:
   workflow_dispatch:
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
   schedule:
-    - cron: "0 0 */7 * *"
+    - cron: "0 0 * * 1"
   # push:
   #   branches:
   #     - main


### PR DESCRIPTION
This pull request includes a change to the `schedule` section of the `Cron` workflow in the `.github/workflows/cron.yml` file. The change modifies the cron schedule to run the workflow weekly on Mondays instead of every 7 days.

* [`.github/workflows/cron.yml`](diffhunk://#diff-69b9772a7fe51bd7c367926862d89ca7d8949cc9832b3645e610a1ec5bfa1ddfR5-R7): Updated the cron schedule to run every Monday at midnight instead of every 7 days.