### PR TITLE
Improve the formatting of changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Installation
 
-### Install Singlefile CLI
+### Install SingleFile CLI
 
-Follow the [Singlefile CLI Installation Guide](https://github.com/gildas-lormeau/single-file-cli?tab=readme-ov-file#installation).
+Follow the [SingleFile CLI Installation Guide](https://github.com/gildas-lormeau/single-file-cli#installation).
 
 ### Install uv
 
@@ -49,7 +49,7 @@ Result: [gist](https://gist.github.com/narumiruna/707786b350fc17197a35ee9ae3d045
 To generate prompts, run the following script:
 
 ```sh
-uv run python meta_prompt.py
+uv run python generate_prompt.py
 ```
 
 For more details, refer to the [OpenAI Prompt Generation Guide](https://platform.openai.com/docs/guides/prompt-generation).

--- a/main.py
+++ b/main.py
@@ -56,8 +56,8 @@ def main(config_file: Path, output_file: Path, use_redis: bool) -> None:
     # output to file
     lines = []
     for doc, changelog in results:
-        lines += [changelog.pretty_repr(doc.name, doc.url)]
-        logger.debug("changelog:\n{}", changelog.pretty_repr(doc.name, doc.url))
+        lines += [changelog.to_markdown(doc.name, doc.url)]
+        logger.debug("changelog:\n{}", changelog.to_markdown(doc.name, doc.url))
 
     with output_file.open("w") as f:
         f.write("\n\n".join(lines))
@@ -78,7 +78,7 @@ def main(config_file: Path, output_file: Path, use_redis: bool) -> None:
             changelog.changes = new_changes
 
         if changelog.changes:
-            post_slack_message(changelog.pretty_repr(doc.name, doc.url))
+            post_slack_message(changelog.to_slack_format(doc.name, doc.url))
 
 
 if __name__ == "__main__":

--- a/src/exchange_changelog/changelog.py
+++ b/src/exchange_changelog/changelog.py
@@ -58,12 +58,26 @@ class Change(BaseModel):
 
         return "\n\n".join(lines)
 
+    def pretty_slack(self) -> str:
+        lines = [
+            f"*<{self.date}>*",
+            self.markdown_content,
+        ]
+
+        if self.keywords:
+            lines += [f"*Keywords:* {', '.join(self.keywords)}"]
+
+        if self.categories:
+            lines += [f"*Categories:* {', '.join(self.categories)}"]
+
+        return "\n\n".join(lines)
+
 
 class Changelog(BaseModel):
     changes: list[Change]
     upcoming_changes: str
 
-    def pretty_repr(self, name: str | None, url: str | None = None) -> str:
+    def to_markdown(self, name: str | None, url: str | None = None) -> str:
         lines = []
 
         if name and url:
@@ -75,6 +89,21 @@ class Changelog(BaseModel):
 
         for changelog in self.changes:
             lines += [changelog.pretty_repr()]
+
+        return "\n\n".join(lines)
+
+    def to_slack_format(self, name: str | None, url: str | None = None) -> str:
+        lines = []
+
+        if name and url:
+            lines += [f"*<{url}|{name}>*"]
+
+        if self.upcoming_changes:
+            lines += ["*Upcoming Changes*"]
+            lines += [self.upcoming_changes]
+
+        for changelog in self.changes:
+            lines += [changelog.pretty_slack()]
 
         return "\n\n".join(lines)
 


### PR DESCRIPTION
This pull request includes several changes to improve the formatting of changelogs and their integration with Slack. The main changes involve renaming methods for clarity and adding new methods to support Slack-specific formatting.

### Changes to changelog formatting:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L59-R60): Updated calls to `pretty_repr` to use the new `to_markdown` method for generating changelog entries in markdown format.
* [`src/exchange_changelog/changelog.py`](diffhunk://#diff-70cd6f84946e65567bb1da977a92f85309ac2c05e7bc74bd93618d45ebefaf86R95-R109): Renamed the `pretty_repr` method to `to_markdown` to better reflect its purpose.

### Slack integration improvements:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L81-R81): Updated calls to `pretty_repr` to use the new `to_slack_format` method for posting changelog entries to Slack.
* [`src/exchange_changelog/changelog.py`](diffhunk://#diff-70cd6f84946e65567bb1da977a92f85309ac2c05e7bc74bd93618d45ebefaf86R61-R80): Added a new method `pretty_slack` to format individual changelog entries for Slack.
* [`src/exchange_changelog/changelog.py`](diffhunk://#diff-70cd6f84946e65567bb1da977a92f85309ac2c05e7bc74bd93618d45ebefaf86R95-R109): Added a new method `to_slack_format` to format the entire changelog for Slack, including upcoming changes and individual entries.